### PR TITLE
Adding opentelemetry exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ The configuration file controls the activated events and data exporters.
 
 To add a data exporter, users should assign a callable function along with function arguments when configuring `exporters`.
 
-This extension provides 4 default exporters.
+This extension provides 5 default exporters.
 
 - [`console_exporter`](https://github.com/educational-technology-collective/jupyterlab-pioneer/blob/main/jupyterlab_pioneer/default_exporters.py#L22), which sends telemetry data to the browser console
 - [`command_line_exporter`](https://github.com/educational-technology-collective/jupyterlab-pioneer/blob/main/jupyterlab_pioneer/default_exporters.py#L48), which sends telemetry data to the python console jupyter is running on
 - [`file_exporter`](https://github.com/educational-technology-collective/jupyterlab-pioneer/blob/main/jupyterlab_pioneer/default_exporters.py#L76), which saves telemetry data to local file
 - [`remote_exporter`](https://github.com/educational-technology-collective/jupyterlab-pioneer/blob/main/jupyterlab_pioneer/default_exporters.py#L106), which sends telemetry data to a remote http endpoint
+- [`opentelemetry_exporter`](https://github.com/educational-technology-collective/jupyterlab-pioneer/blob/main/jupyterlab_pioneer/default_exporters.py#L162), which sends telemetry data via otlp.
 
 Additionally, users can write customized exporters in the configuration file.
 

--- a/configuration_examples/all_exporters/jupyter_jupyterlab_pioneer_config.py
+++ b/configuration_examples/all_exporters/jupyter_jupyterlab_pioneer_config.py
@@ -2,11 +2,12 @@
 
 """An array of the exporters.
 
-This extension provides 4 default exporters:
+This extension provides 5 default exporters:
 `console_exporter`, which sends telemetry data to the browser console.
 `command_line_exporter`, which sends telemetry data to the python console jupyter is running on.
 `file_exporter`, which saves telemetry data to local file.
 `remote_exporter`, which sends telemetry data to a remote http endpoint.
+`opentelemetry_exporter`, which sends telemetry data via otlp.
 
 Additionally, users can import default exporters or write customized exporters in the configuration file.
 """

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -6,7 +6,7 @@ Overview
 
 The configuration file controls the activated events and data exporters.
 
-This extension provides 4 default exporters in the :mod:`.default_exporters` module:
+This extension provides 5 default exporters in the :mod:`.default_exporters` module:
 
 1. :func:`.default_exporters.console_exporter`, which sends telemetry data to the browser console.
 
@@ -15,6 +15,8 @@ This extension provides 4 default exporters in the :mod:`.default_exporters` mod
 3. :func:`.default_exporters.file_exporter`, which saves telemetry data to local file.
 
 4. :func:`.default_exporters.remote_exporter`, which sends telemetry data to a remote http endpoint.
+
+5. :func:`.default_exporters.opentelemetry_exporter`, which sends telemetry data via otlp.
 
 Default exporters will be activated if the exporter name is included by the configuration file.
 

--- a/jupyterlab_pioneer/application.py
+++ b/jupyterlab_pioneer/application.py
@@ -46,7 +46,7 @@ class JupyterLabPioneerApp(ExtensionApp):
     exporters = List([]).tag(config=True)
     """ An array of the exporters defined in the configuration file.
 
-    This extension provides 4 default exporters in the :mod:`.default_exporters` module:
+    This extension provides 5 default exporters in the :mod:`.default_exporters` module:
 
     :func:`.default_exporters.console_exporter`, which sends telemetry data to the browser console.
 
@@ -55,6 +55,8 @@ class JupyterLabPioneerApp(ExtensionApp):
     :func:`.default_exporters.file_exporter`, which saves telemetry data to local file.
 
     :func:`.default_exporters.remote_exporter`, which sends telemetry data to a remote http endpoint.
+
+    :func:`.default_exporters.opentelemetry_exporter`, which sends telemetry data via otlp.
 
     Additionally, users can import default exporters or write customized exporters in the configuration file.
 

--- a/jupyterlab_pioneer/default_exporters.py
+++ b/jupyterlab_pioneer/default_exporters.py
@@ -41,6 +41,7 @@ def console_exporter(args: dict) -> dict:
                 }
 
     """
+
     return {"exporter": args.get("id") or "ConsoleExporter", "message": args["data"]}
 
 
@@ -65,6 +66,8 @@ def command_line_exporter(args: dict) -> dict:
                 }
     
     """
+
+    print(args["data"])
     return {
         "exporter": args.get("id") or "CommandLineExporter",
     }

--- a/jupyterlab_pioneer/default_exporters.py
+++ b/jupyterlab_pioneer/default_exporters.py
@@ -41,7 +41,6 @@ def console_exporter(args: dict) -> dict:
                 }
 
     """
-
     return {"exporter": args.get("id") or "ConsoleExporter", "message": args["data"]}
 
 
@@ -66,8 +65,6 @@ def command_line_exporter(args: dict) -> dict:
                 }
     
     """
-
-    print(args["data"])
     return {
         "exporter": args.get("id") or "CommandLineExporter",
     }
@@ -160,9 +157,27 @@ async def remote_exporter(args: dict) -> dict:
     }
 
 
+def opentelemetry_exporter(args: dict) -> None:
+    """This exporter sends telemetry data via otlp
+
+    """
+    from opentelemetry import trace
+
+    current_span = trace.get_current_span()
+    event_detail = args['data']['eventDetail']
+    notebook_state = args['data']['notebookState']
+    attributes = {
+        "notebookSessionId": notebook_state['sessionID'],
+        'notebookPath': notebook_state['notebookPath'],
+        "event": event_detail['eventName']
+    }
+    current_span.add_event(event_detail['eventName'], attributes=attributes)
+
+
 default_exporters: "dict[str, Callable[[dict], dict or Awaitable[dict]]]" = {
     "console_exporter": console_exporter,
     "command_line_exporter": command_line_exporter,
     "file_exporter": file_exporter,
     "remote_exporter": remote_exporter,
+    "opentelementry_exporter": opentelemetry_exporter,
 }

--- a/jupyterlab_pioneer/default_exporters.py
+++ b/jupyterlab_pioneer/default_exporters.py
@@ -1,4 +1,4 @@
-"""This module provides 4 default exporters for the extension. If the exporter function name is mentioned in the configuration file or in the notebook metadata, the extension will use the corresponding exporter function when the jupyter lab event is fired.
+"""This module provides 5 default exporters for the extension. If the exporter function name is mentioned in the configuration file or in the notebook metadata, the extension will use the corresponding exporter function when the jupyter lab event is fired.
 
 Attributes:
     default_exporters: a map from function names to callable exporter functions::
@@ -8,6 +8,7 @@ Attributes:
             "command_line_exporter": command_line_exporter,
             "file_exporter": file_exporter,
             "remote_exporter": remote_exporter,
+            "opentelemetry_exporter": opentelemetry_exporter,
         }
 """
 
@@ -159,8 +160,7 @@ async def remote_exporter(args: dict) -> dict:
         },
     }
 
-
-def opentelemetry_exporter(args: dict) -> None:
+def opentelemetry_exporter(args: dict) -> dict:
     """This exporter sends telemetry data via otlp
 
     """
@@ -176,6 +176,9 @@ def opentelemetry_exporter(args: dict) -> None:
     }
     current_span.add_event(event_detail['eventName'], attributes=attributes)
 
+    return {
+        "exporter": args.get("id") or "OpenTelemetryExporter",
+    }
 
 default_exporters: "dict[str, Callable[[dict], dict or Awaitable[dict]]]" = {
     "console_exporter": console_exporter,

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -33,7 +33,7 @@ export interface ExporterArgs {
 
 export interface Exporter {
   /**
-   * Exporter type, should be one of "console_exporter", "command_line_exporter", "file_exporter", "remote_exporter" or "custom_exporter"
+   * Exporter type, should be one of "console_exporter", "command_line_exporter", "file_exporter", "remote_exporter", "opentelemetry_exporter" or "custom_exporter"
    */
   type: string;
   /**


### PR DESCRIPTION
I was really facinated by this project since it enables telemetry on the jupyterlab client to be recorded on the server side. This PR is to add support for an opentelemetry exporter and additionally document how to run jupyterlab with it enabled.

I recommend running jaeger locally (easist way to view traces).

```yaml
version: "3"

services:
  jaeger:
    image: jaegertracing/all-in-one:latest
    ports:
      - "4317:4317"
      - "6831:6831/udp"
      - "16686:16686"   
```

Next install this package along with several additional packages

```
git clone <this repo>
pip install .
pip install opentelemetry-exporter-otlp-proto-grpc opentelemetry-instrumentation-tornado opentelemetry-distro jupyterlab
```

Now apply the typical installation of the notebook config detailed in the readme to activate `activeEvents` and `exporters`.

Then run jupyterlab with instrumentation notice how we call `jupyter-lab` and not `jupyter lab`.

```shell
OTEL_SERVICE_NAME=jupyter-otel OTEL_TRACES_EXPORTER=otlp OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317  opentelemetry-instrument jupyter-lab
```

Now you can view traces via jaeger by visiting `localhost:16676` make sure to do many things on the notebooks to create events etc.

![image](https://github.com/educational-technology-collective/jupyterlab-pioneer/assets/1740337/59173dff-eb41-49d2-bfe4-a126af11c355)

When we dive into one of the traces we see

![image](https://github.com/educational-technology-collective/jupyterlab-pioneer/assets/1740337/20588282-a0e0-453a-9b33-4e555df7ad81)

Take this example where we filter for all events which are `event=CellExecuteEvent`. This is a very basic PR but my hope from this is that this framework could more more aligned with OTEL and allow jupyterlab first class support for monitoring and telemetry. Since it does support http, kafka, influx, console, etc as exporters out of the box. Additionally this allow full monitoring of the tornado service and all api methods called.