### PR TITLE
Add relevant github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,153 @@
+name: Build
+
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+    - name: Install dependencies
+      run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+
+    - name: Lint the extension
+      run: |
+        set -eux
+        jlpm
+        jlpm run lint:check
+
+    #- name: Test the extension
+    #  run: |
+    #    set -eux
+    #    jlpm run test
+
+    - name: Build the extension
+      run: |
+        set -eux
+        python -m pip install .[test]
+
+        jupyter labextension list
+        jupyter labextension list 2>&1 | grep -ie "jupyterlab-pioneer.*OK"
+        python -m jupyterlab.browser_check
+
+    - name: Package the extension
+      run: |
+        set -eux
+
+        pip install build
+        python -m build
+        pip uninstall -y "jupyterlab_pioneer" jupyterlab
+
+    - name: Upload extension packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: extension-artifacts
+        path: dist/jupyterlab_pioneer*
+        if-no-files-found: error
+
+  test_isolated:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.9'
+        architecture: 'x64'
+    - uses: actions/download-artifact@v4
+      with:
+        name: extension-artifacts
+    - name: Install and Test
+      run: |
+        set -eux
+        # Remove NodeJS, twice to take care of system and locally installed node versions.
+        sudo rm -rf $(which node)
+        sudo rm -rf $(which node)
+
+        pip install "jupyterlab>=4.0.0,<5" jupyterlab_pioneer*.whl
+
+
+        jupyter labextension list
+        jupyter labextension list 2>&1 | grep -ie "jupyterlab-pioneer.*OK"
+        python -m jupyterlab.browser_check --no-browser-test
+
+  integration-tests:
+    name: Integration tests
+    needs: build
+    runs-on: ubuntu-latest
+
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Base Setup
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+    - name: Download extension package
+      uses: actions/download-artifact@v4
+      with:
+        name: extension-artifacts
+
+    - name: Install the extension
+      run: |
+        set -eux
+        python -m pip install "jupyterlab>=4.0.0,<5" jupyterlab_pioneer*.whl
+
+    #- name: Install dependencies
+    #  working-directory: ui-tests
+    #  env:
+    #    YARN_ENABLE_IMMUTABLE_INSTALLS: 0
+    #    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+    #  run: jlpm install
+
+    #- name: Set up browser cache
+    #  uses: actions/cache@v4
+    #  with:
+    #    path: |
+    #      ${{ github.workspace }}/pw-browsers
+    #    key: ${{ runner.os }}-${{ hashFiles('ui-tests/yarn.lock') }}
+
+    #- name: Install browser
+    #  run: jlpm playwright install chromium
+    #  working-directory: ui-tests
+
+    #- name: Execute integration tests
+    #  working-directory: ui-tests
+    #  run: |
+    #    jlpm playwright test
+
+    #- name: Upload Playwright Test report
+    #  if: always()
+    #  uses: actions/upload-artifact@v4
+    #  with:
+    #    name: jupyterlab_pioneer-playwright-tests
+    #    path: |
+    #      ui-tests/test-results
+    #      ui-tests/playwright-report
+
+  check_links:
+    name: Check Links
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -1,0 +1,48 @@
+name: "Step 1: Prep Release"
+on:
+  workflow_dispatch:
+    inputs:
+      version_spec:
+        description: "New Version Specifier"
+        default: "next"
+        required: false
+      branch:
+        description: "The branch to target"
+        required: false
+      post_version_spec:
+        description: "Post Version Specifier"
+        required: false
+      # silent:
+      #   description: "Set a placeholder in the changelog and don't publish the release."
+      #   required: false
+      #   type: boolean
+      since:
+        description: "Use PRs with activity since this date or git reference"
+        required: false
+      since_last_stable:
+        description: "Use PRs with activity since the last stable git tag"
+        required: false
+        type: boolean
+jobs:
+  prep_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Prep Release
+        id: prep-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version_spec: ${{ github.event.inputs.version_spec }}
+          # silent: ${{ github.event.inputs.silent }}
+          post_version_spec: ${{ github.event.inputs.post_version_spec }}
+          branch: ${{ github.event.inputs.branch }}
+          since: ${{ github.event.inputs.since }}
+          since_last_stable: ${{ github.event.inputs.since_last_stable }}
+
+      - name: "** Next Step **"
+        run: |
+          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,57 @@
+name: "Step 2: Publish Release"
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The target branch"
+        required: false
+      release_url:
+        description: "The URL of the draft GitHub release"
+        required: false
+      steps_to_skip:
+        description: "Comma separated list of steps to skip"
+        required: false
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+    steps:
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Populate Release
+        id: populate-release
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: ${{ github.event.inputs.branch }}
+          release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+
+      - name: Finalize Release
+        id: finalize-release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          release_url: ${{ steps.populate-release.outputs.release_url }}
+
+      - name: "** Next Step **"
+        if: ${{ success() }}
+        run: |
+          echo "Verify the final release"
+          echo ${{ steps.finalize-release.outputs.release_url }}
+      - name: "** Failure Message **"
+        if: ${{ failure() }}
+        run: |
+          echo "Failed to Publish the Draft Release Url:"
+          echo ${{ steps.populate-release.outputs.release_url }}

--- a/.github/workflows/update-integration-tests.yml
+++ b/.github/workflows/update-integration-tests.yml
@@ -1,0 +1,86 @@
+name: Update Playwright Snapshots
+
+on:
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-snapshots:
+    if: >
+      (
+        github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'COLLABORATOR' ||
+        github.event.issue.author_association == 'MEMBER'
+      ) && github.event.issue.pull_request && contains(github.event.comment.body, 'please update snapshots')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: React to the triggering comment
+        run: |
+          gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions --raw-field 'content=+1'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get PR Info
+        id: pr
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COMMENT_AT: ${{ github.event.comment.created_at }}
+        run: |
+          pr="$(gh api /repos/${GH_REPO}/pulls/${PR_NUMBER})"
+          head_sha="$(echo "$pr" | jq -r .head.sha)"
+          pushed_at="$(echo "$pr" | jq -r .pushed_at)"
+
+          if [[ $(date -d "$pushed_at" +%s) -gt $(date -d "$COMMENT_AT" +%s) ]]; then
+              echo "Updating is not allowed because the PR was pushed to (at $pushed_at) after the triggering comment was issued (at $COMMENT_AT)"
+              exit 1
+          fi
+
+          echo "head_sha=$head_sha" >> $GITHUB_OUTPUT
+
+      - name: Checkout the branch from the PR that triggered the job
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
+      - name: Validate the fetched branch HEAD revision
+        env:
+          EXPECTED_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          actual_sha="$(git rev-parse HEAD)"
+
+          if [[ "$actual_sha" != "$EXPECTED_SHA" ]]; then
+              echo "The HEAD of the checked out branch ($actual_sha) differs from the HEAD commit available at the time when trigger comment was submitted ($EXPECTED_SHA)"
+              exit 1
+          fi
+
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+
+      - name: Install dependencies
+        run: python -m pip install -U "jupyterlab>=4.0.0,<5"
+
+      - name: Install extension
+        run: |
+          set -eux
+          jlpm
+          python -m pip install .
+
+      - uses: jupyterlab/maintainer-tools/.github/actions/update-snapshots@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Playwright knows how to start JupyterLab server
+          start_server_script: 'null'
+          test_folder: ui-tests
+          npm_client: jlpm

--- a/package.json
+++ b/package.json
@@ -136,11 +136,7 @@
                     "selector": "interface",
                     "format": [
                         "PascalCase"
-                    ],
-                    "custom": {
-                        "regex": "^I[A-Z]",
-                        "match": true
-                    }
+                    ]
                 }
             ],
             "@typescript-eslint/no-unused-vars": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,15 +27,15 @@ export interface IJupyterLabPioneer {
    * Send event data to exporters defined in the configuration file.
    *
    * @param {NotebookPanel} notebookPanel The notebook panel the extension currently listens to.
-   * @param {Object} eventDetail An object containing event details.
+   * @param {object} eventDetail An object containing event details.
    * @param {Exporter} exporter The exporter configuration.
    * @param {Boolean} logWholeNotebook A boolean indicating whether to log the entire notebook or not.
    */
   publishEvent(
     notebookPanel: NotebookPanel,
-    eventDetail: Object,
+    eventDetail: object,
     exporter: Exporter,
-    logWholeNotebook?: Boolean
+    logWholeNotebook?: boolean
   ): Promise<void>;
 }
 
@@ -71,9 +71,9 @@ class JupyterLabPioneer implements IJupyterLabPioneer {
 
   async publishEvent(
     notebookPanel: NotebookPanel,
-    eventDetail: Object,
+    eventDetail: object,
     exporter: Exporter,
-    logWholeNotebook?: Boolean
+    logWholeNotebook?: boolean
   ) {
     if (!notebookPanel) {
       throw Error('router is listening to a null notebook panel');

--- a/src/producer.ts
+++ b/src/producer.ts
@@ -44,7 +44,7 @@ export class ActiveCellChangeEventProducer {
                 event,
                 exporter,
                 exporter.activeEvents?.find(
-                  o => o.name == ActiveCellChangeEventProducer.id
+                  o => o.name === ActiveCellChangeEventProducer.id
                 )?.logWholeNotebook
               );
             }
@@ -85,7 +85,7 @@ export class CellAddEventProducer {
                 event,
                 exporter,
                 exporter.activeEvents?.find(
-                  o => o.name == CellAddEventProducer.id
+                  o => o.name === CellAddEventProducer.id
                 )?.logWholeNotebook
               );
             }
@@ -125,8 +125,9 @@ export class CellEditEventProducer {
             notebookPanel,
             event,
             exporter,
-            exporter.activeEvents?.find(o => o.name == CellEditEventProducer.id)
-              ?.logWholeNotebook
+            exporter.activeEvents?.find(
+              o => o.name === CellEditEventProducer.id
+            )?.logWholeNotebook
           );
         }
       });
@@ -195,14 +196,16 @@ export class CellExecuteEventProducer {
         args: {
           notebook: Notebook;
           cell: Cell<ICellModel>;
-          success: Boolean;
+          success: boolean;
           error?: KernelError | null | undefined;
         }
       ) => {
         if (notebookPanel.content === args.notebook) {
           const executedCell = {
             id: args.cell.model.id,
-            index: args.notebook.widgets.findIndex(value => value == args.cell),
+            index: args.notebook.widgets.findIndex(
+              value => value === args.cell
+            ),
             type: args.cell.model.type
           };
           const event = {
@@ -225,7 +228,7 @@ export class CellExecuteEventProducer {
                 event,
                 exporter,
                 exporter.activeEvents?.find(
-                  o => o.name == CellExecuteEventProducer.id
+                  o => o.name === CellExecuteEventProducer.id
                 )?.logWholeNotebook
               );
             }
@@ -265,7 +268,7 @@ export class CellRemoveEventProducer {
                 event,
                 exporter,
                 exporter.activeEvents?.find(
-                  o => o.name == CellRemoveEventProducer.id
+                  o => o.name === CellRemoveEventProducer.id
                 )?.logWholeNotebook
               );
             }
@@ -308,7 +311,7 @@ export class ClipboardCopyEventProducer {
             event,
             exporter,
             exporter.activeEvents?.find(
-              o => o.name == ClipboardCopyEventProducer.id
+              o => o.name === ClipboardCopyEventProducer.id
             )?.logWholeNotebook
           );
         }
@@ -349,7 +352,7 @@ export class ClipboardCutEventProducer {
             event,
             exporter,
             exporter.activeEvents?.find(
-              o => o.name == ClipboardCutEventProducer.id
+              o => o.name === ClipboardCutEventProducer.id
             )?.logWholeNotebook
           );
         }
@@ -392,7 +395,7 @@ export class ClipboardPasteEventProducer {
             event,
             exporter,
             exporter.activeEvents?.find(
-              o => o.name == ClipboardPasteEventProducer.id
+              o => o.name === ClipboardPasteEventProducer.id
             )?.logWholeNotebook
           );
         }
@@ -426,7 +429,7 @@ export class NotebookHiddenEventProducer {
               event,
               exporter,
               exporter.activeEvents?.find(
-                o => o.name == NotebookHiddenEventProducer.id
+                o => o.name === NotebookHiddenEventProducer.id
               )?.logWholeNotebook
             );
           }
@@ -460,7 +463,7 @@ export class NotebookOpenEventProducer {
             event,
             exporter,
             exporter.activeEvents?.find(
-              o => o.name == NotebookOpenEventProducer.id
+              o => o.name === NotebookOpenEventProducer.id
             )?.logWholeNotebook
           );
           this.produced = true;
@@ -493,7 +496,7 @@ export class NotebookSaveEventProducer {
                 event,
                 exporter,
                 exporter.activeEvents?.find(
-                  o => o.name == NotebookSaveEventProducer.id
+                  o => o.name === NotebookSaveEventProducer.id
                 )?.logWholeNotebook
               );
             }
@@ -566,7 +569,7 @@ export class NotebookScrollEventProducer {
               event,
               exporter,
               exporter.activeEvents?.find(
-                o => o.name == NotebookScrollEventProducer.id
+                o => o.name === NotebookScrollEventProducer.id
               )?.logWholeNotebook
             );
           }
@@ -602,7 +605,7 @@ export class NotebookVisibleEventProducer {
               event,
               exporter,
               exporter.activeEvents?.find(
-                o => o.name == NotebookVisibleEventProducer.id
+                o => o.name === NotebookVisibleEventProducer.id
               )?.logWholeNotebook
             );
           }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -24,11 +24,11 @@ export interface ExporterArgs {
   /**
    * Additional parameters to pass to the http endpoint (optional for remote exporter)
    */
-  params?: Object;
+  params?: object;
   /**
    * Environment variables to pass to the http endpoint (optional for remote exporter)
    */
-  env?: Object[];
+  env?: object[];
 }
 
 export interface Exporter {

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -15,7 +15,8 @@ export const sendInfoNotification = (
   if (isGlobal && exporterMessage) {
     message = `Telemetry data is being logged to ${exporterMessage} through jupyterlab-pioneer. \n See Help menu -> JupyterLab Pioneer for more details.`;
   } else if (isGlobal && !exporterMessage) {
-    message = `Telemetry data is being logged through jupyterlab-pioneer. \n See Help menu -> JupyterLab Pioneer for more details.`;
+    message =
+      'Telemetry data is being logged through jupyterlab-pioneer. \n See Help menu -> JupyterLab Pioneer for more details.';
   } else {
     message = `Embedded telemetry settings loaded. Telemetry data is being logged to ${exporterMessage} now.`;
   }


### PR DESCRIPTION
Dear maintainers,

this pull request adds to jupyterlab-pioneer relevant github worflows as provided by the [jupyterlab extension template](https://github.com/jupyterlab/extension-template).

The errors produced by the linter have been fixed, except for those related to the naming of the interfaces (I had to remove the custom rule from `package.json`).

A successful run of the workflows is available at https://github.com/cmarmo/jupyterlab-pioneer/pull/1.
For this one, the `README.md` should be fixed via all-contributors, I guess.

Thank you for considering this pull request.