### PR TITLE
Let the user hide the notification with "Don't show again" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ See [RELEASE](RELEASE.md)
 
 ## Contributors ✨
 
-Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/emoji-key/#natural-language-processing)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -20,7 +20,20 @@ export const sendInfoNotification = (
   } else {
     message = `Embedded telemetry settings loaded. Telemetry data is being logged to ${exporterMessage} now.`;
   }
-  Notification.info(message, { autoClose: 20000 });
+  const close = localStorage.getItem('pioneer:autoClose');
+  if (close !== null) {
+    Notification.info(message, { autoClose: 0 });
+  } else {
+    Notification.info(message, {
+      actions: [
+        {
+          label: "Don't show again",
+          callback: () => localStorage.setItem('pioneer:autoClose', '0')
+        }
+      ],
+      autoClose: 10000
+    });
+  }
 };
 
 export const addInfoToHelpMenu = (


### PR DESCRIPTION
Dear maintainers,
this pull request adds the possibility to hide the notification about telemetry if the user push the "don't show again" button.
When hidden the notification is still available in the notification bell icon on the bottom right.

Closes #46.
cc: @nthiery